### PR TITLE
[LIB] Poetry minimal version, Python version freeze

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -383,5 +383,5 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.11"
-content-hash = "9664d0956dc7a015a81b6552ecf896e547ba2ec70f291154bfffb46a25c02d4e"
+python-versions = "~3.11"
+content-hash = "6518a1dfda3efc3560a5623756ec17456ae5cdef081fe84c5413d59c645af933"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "~3.11"
 dataclasses-json = "*"
 hjson="*"
 events = "*"
@@ -26,5 +26,5 @@ pre-commit = "*"
 show_error_codes = true
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Changed:
 - Froze the exact required python interpreter version as 3.11
 - Poetry minimal version is now >1.0.0